### PR TITLE
Fix #157 fatal error.

### DIFF
--- a/includes/class-alg-wc-pif-main.php
+++ b/includes/class-alg-wc-pif-main.php
@@ -645,6 +645,9 @@ if ( ! class_exists( 'Alg_WC_PIF_Main' ) ) {
 		 * @since   1.0.0
 		 */
 		public function add_files_to_email_attachments( $attachments, $status, $order ) {
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return $attachments;
+			}
 			if (
 			( 'new_order' === $status && 'yes' === get_wc_pif_option( 'attach_to_admin_new_order', 'yes' ) ) ||
 			( 'customer_processing_order' === $status && 'yes' === get_wc_pif_option( 'attach_to_customer_processing_order', 'yes' ) )


### PR DESCRIPTION
Fix #157 fatal error.

**Tetsing note -** 
When an order is placed with an attachment and it is marked as 'On Hold' after placement, an email is triggered for that status — and that's when this error occurs.