### PR TITLE
Fix PHP 8.2 deprecation: declare is_wc_version_below_3_2_0 property

### DIFF
--- a/includes/admin/class-alg-wc-settings-pif.php
+++ b/includes/admin/class-alg-wc-settings-pif.php
@@ -21,6 +21,14 @@ if ( ! class_exists( 'Alg_WC_Settings_PIF' ) ) :
 	class Alg_WC_Settings_PIF extends WC_Settings_Page {
 
 		/**
+		 * WC version below 3.2.0.
+		 *
+		 * @since 1.1.1
+		 * @var bool|null
+		 */
+		protected $is_wc_version_below_3_2_0 = null;
+
+		/**
 		 * Constructor.
 		 *
 		 * @version 1.0.0


### PR DESCRIPTION
Fix #165 PHP 8.2 deprecation warning by declaring the is_wc_version_below_3_2_0 property in Alg_WC_Settings_PIF