### PR TITLE
Bug fixes

### DIFF
--- a/includes/class-pif-cart.php
+++ b/includes/class-pif-cart.php
@@ -120,10 +120,6 @@ class PIF_Cart {
 						$field_value = $session_data['files'][ $field_name ] ?? '';
 					}
 				} else {
-					if ( 'select' === $product_input_field['type'] && $_POST[ $field_name ] === 'placeholder' ) { //phpcs:ignore
-						$field_value = '';
-					}
-
 					if ( isset( $_POST[ $field_name ] ) ) { // phpcs:ignore
 						$field_value = sanitize_text_field( wp_unslash( $_POST[ $field_name ] ) ); // phpcs:ignore
 						if ( is_array( $field_value ) ) {

--- a/includes/class-pif-express-checkout.php
+++ b/includes/class-pif-express-checkout.php
@@ -279,12 +279,12 @@ class PIF_Express_Checkout {
 			$global_fields = get_option( 'pif_field_settings', array() );
 			$product_fields = get_post_meta( $product_id, 'pif_field_settings', true );
 
-			$fields = ( 'local' === $scope ) ? $product_fields : $global_fields;
+			$all_fields = ( 'local' === $scope ) ? $product_fields : $global_fields;
 
-			if ( ! is_array( $fields ) ) {
+			if ( ! is_array( $all_fields ) ) {
 				continue;
 			}
-			foreach ( $fields as $key => $field ) {
+			foreach ( $all_fields as $key => $field ) {
 				$field_id = $field['id'] ?? 1;
 				$enabled  = isset( $field['enabled'] ) && ( true === $field['enabled'] || 'yes' === $field['enabled'] ) ? true : false;
 
@@ -312,12 +312,12 @@ class PIF_Express_Checkout {
 			$global_fields  = get_option( 'pif_field_settings', array() );
 			$product_fields = get_post_meta( $product_id, 'pif_field_settings', true );
 
-			$fields = ( 'local' === $scope ) ? $product_fields : $global_fields;
+			$all_fields = ( 'local' === $scope ) ? $product_fields : $global_fields;
 
-			if ( ! is_array( $fields ) ) {
+			if ( ! is_array( $all_fields ) ) {
 				continue;
 			}
-			foreach ( $fields as $key => $field ) {
+			foreach ( $all_fields as $key => $field ) {
 				$field_id = $field['id'] ?? 1;
 				$enabled  = isset( $field['enabled'] ) && ( true === $field['enabled'] || 'yes' === $field['enabled'] ) ? true : false;
 				$required  = isset( $field['required'] ) && ( true === $field['required'] || 'yes' === $field['required'] ) ? true : false;

--- a/includes/class-product-input-fields.php
+++ b/includes/class-product-input-fields.php
@@ -273,11 +273,12 @@ final class Product_Input_Fields {
 	private function handle_localization() {
 		$domain = 'product-input-fields-for-woocommerce';
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
-		$loaded = load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . 'plugins/' . $domain . '-pro/' . $domain . '-' . $locale . '.mo' );
+		$loaded = load_textdomain( $domain, trailingslashit( WP_LANG_DIR ) . $domain . '-' . $locale . '.mo' );
+
 		if ( $loaded ) {
 			return $loaded;
 		} else {
-			load_plugin_textdomain( $domain, false, dirname( plugin_basename( __FILE__ ) ) . '/langs/' );
+			load_plugin_textdomain( $domain, false, dirname( plugin_basename( PIF_FILE ) ) . '/languages/' );
 		}
 	}
 

--- a/src/screens/fieldSettings.js
+++ b/src/screens/fieldSettings.js
@@ -150,28 +150,6 @@ function FieldSettings({control, reset, watch, getValues }) {
                             />
                         ),
                     },
-                    {
-                        name: 'to_uppercase',
-                        defaultValue: '',
-                        label: __( 'Uppercase', 'product-input-fields-for-woocommerce' ),
-                        showWhen: type === 'text' || type === 'textarea',
-                        render: ( field ) => (
-                            <RadioControl
-                                selected={ field.value }
-                                options={[
-                                    {
-                                        label: __('Converts all characters to uppercase version.', 'product-input-fields-for-woocommerce'),
-                                        value: 'all_letters_uppercase',
-                                    },
-                                    {
-                                        label: __('Converts only first letter of first word to uppercase version.', 'product-input-fields-for-woocommerce'),
-                                        value: 'only_first_letter_uppercase',
-                                    },
-                                ]}
-                                onChange={ field.onChange }
-                            />
-                        ),
-                    },
                 ] }
             />
 


### PR DESCRIPTION
Fix #180 - Required field validation was displayed even when the value was selected. This was due to the express checkout changes, where the $fields array in get_required_fields() was being overwritten.

Fix #183 - Remove the Uppercase related settings which are not present in lite version.

Fix #179 - Fix the error with _load_textdomain_just_in_time for the plugin.