### PR TITLE
Fix the fatal error with lite to pro migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 [Rr]elease/
 x64/
 build/
+dist/
 
 # Dependency directories
 node_modules/

--- a/includes/class-pif-files.php
+++ b/includes/class-pif-files.php
@@ -26,10 +26,10 @@ class PIF_Files {
 	 */
 	public static function include_files() {
 
-        PIF()::include_file( 'api/class-pif-admin-api.php' );
-        PIF()::include_file( 'api/class-pif-admin-api-settings.php' );
-        PIF()::include_file( 'api/class-pif-product-api.php' );
-        PIF()::include_file( 'api/class-pif-store.php' );
+        PIF_Lite()::include_file( 'api/class-pif-admin-api.php' );
+        PIF_Lite()::include_file( 'api/class-pif-admin-api-settings.php' );
+        PIF_Lite()::include_file( 'api/class-pif-product-api.php' );
+        PIF_Lite()::include_file( 'api/class-pif-store.php' );
 
         $tyche_files = array(
             'class-tyche-pif-tracking.php',
@@ -38,26 +38,26 @@ class PIF_Files {
 
         foreach ( $tyche_files as $tyche_file ) {
             if ( file_exists( PIF_PLUGIN_DIR_PATH . '/includes/' . $tyche_file ) ) {
-                PIF()::include_file( $tyche_file );
+                PIF_Lite()::include_file( $tyche_file );
             }
         }
 		// Functions.
-		PIF()::include_file( 'pif-functions.php' );
+		PIF_Lite()::include_file( 'pif-functions.php' );
 
-		PIF()::include_file( 'admin/class-pif-admin.php' );
-		PIF()::include_file( 'admin/class-pif-product-admin.php' );
+		PIF_Lite()::include_file( 'admin/class-pif-admin.php' );
+		PIF_Lite()::include_file( 'admin/class-pif-product-admin.php' );
 
 		// // Scripts.
-		PIF()::include_file( 'admin/class-pif-admin-scripts.php' );
+		PIF_Lite()::include_file( 'admin/class-pif-admin-scripts.php' );
 		new PIF_Admin_Scripts();
 
-		PIF()::include_file( 'class-pif-update.php' );
+		PIF_Lite()::include_file( 'class-pif-update.php' );
 		
 		// Frontend
-		PIF()::include_file( 'class-pif-product.php' );
-		PIF()::include_file( 'class-pif-cart.php' );
-		PIF()::include_file( 'class-pif-order.php' );
-		PIF()::include_file( 'class-pif-express-checkout.php' );
+		PIF_Lite()::include_file( 'class-pif-product.php' );
+		PIF_Lite()::include_file( 'class-pif-cart.php' );
+		PIF_Lite()::include_file( 'class-pif-order.php' );
+		PIF_Lite()::include_file( 'class-pif-express-checkout.php' );
 		new PIF_Express_Checkout();
 	}
 

--- a/product-input-fields-for-woocommerce.php
+++ b/product-input-fields-for-woocommerce.php
@@ -39,8 +39,8 @@ if ( ! class_exists( 'Product_Input_Fields', false ) ) {
  *
  * @since  1.0
  */
-function PIF() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function PIF_Lite() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	return Product_Input_Fields::instance();
 }
 
-PIF();
+PIF_Lite();


### PR DESCRIPTION
Fatal error was displayed when migrating from lite to pro due to the use of same class name. Changed the class name in the lite version to fix the error.

Fix #192 