### PR TITLE
Display only 1 field if more fields are present in settings

### DIFF
--- a/includes/class-pif-product.php
+++ b/includes/class-pif-product.php
@@ -276,6 +276,10 @@ class PIF_Product {
 		$global_fields 	= get_option( 'pif_field_settings', array() );
 		$product_fields = get_post_meta( $product_id, 'pif_field_settings', true );
 
+		if ( count( $global_fields ) >= 2 ) {
+			$global_fields = array_slice( $global_fields, 0, 1, true );
+		}
+
 		$html = self::get_field_html( $global_fields, 'global', $product_id );
 
 		if ( true === pif_get_option( 'local_enabled' ) || 'yes' === pif_get_option( 'local_enabled' ) ) {

--- a/src/screens/fieldSettings.js
+++ b/src/screens/fieldSettings.js
@@ -40,7 +40,7 @@ function FieldSettings({control, reset, watch, getValues }) {
                 fields={ [
                     {
                         name: 'type',
-                        defaultValue: false,
+                        defaultValue: 'text',
                         label: __( 'Field Type', 'product-input-fields-for-woocommerce' ),
                         render: ( field ) => (
                             <SelectControl


### PR DESCRIPTION
When we rollback to lite version from pro version, only the first field should be displayed on the frontend.